### PR TITLE
Making Product Version and File Version on the dll match the Assembly Version

### DIFF
--- a/src/Hangfire.Dashboard.Authorization/Properties/AssemblyInfo.cs
+++ b/src/Hangfire.Dashboard.Authorization/Properties/AssemblyInfo.cs
@@ -16,5 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("34dd541a-5bdb-402f-8ec0-9aac8e3331ae")]
-
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Having the AssemblyFileVersion attribute defined causes the product version and file version in the dll properties to follow it. Removing it makes those properties follow the assembly version. This was causing issues within a MSI my project uses, since the MSI thinks the version is always 1.0.0.0 and doesn't deploy the new dll.
